### PR TITLE
Better Cleanup

### DIFF
--- a/jsonary.js
+++ b/jsonary.js
@@ -6175,8 +6175,8 @@ publicApi.UriTemplate = UriTemplate;
         for (var key in pageContext.elementLookup) {
             delete pageContext.elementLookup[key];
         };
-        //delete pageContext;
-        //pageContext = new RenderContext();
+        delete pageContext;
+        pageContext = new RenderContext();
     };
 
     function cleanupGently(){

--- a/plugins/jsonary.render.js
+++ b/plugins/jsonary.render.js
@@ -460,8 +460,8 @@
         for (var key in pageContext.elementLookup) {
             delete pageContext.elementLookup[key];
         };
-        //delete pageContext;
-        //pageContext = new RenderContext();
+        delete pageContext;
+        pageContext = new RenderContext();
     };
 
     function cleanupGently(){


### PR DESCRIPTION
To enable better cleanup i added cleanupGently and cleanupAll. cleanupGently is your original cleanup happening every 30s. I made this also callable via Jsonary.render.cleanupGently(). cleanupAll is also callable via Jsonary.render.cleanupAll() and should be called only when your shure that there should be no more Jsonary objects.

see issue #52 for more details...
Ognian
