### PR TITLE
- allow to create an (empty) array if the value is null, since this is ...

### DIFF
--- a/jsonary/schemaset.js
+++ b/jsonary/schemaset.js
@@ -1011,7 +1011,7 @@ SchemaList.prototype = {
 			origValue = callback;
 			callback = tmp;
 		}
-		if (typeof origValue !== 'undefined' && !Array.isArray(origValue)) {
+		if (typeof origValue !== 'undefined' && origValue !== null && !Array.isArray(origValue)) {
 			return undefined;
 		}
 		var thisSchemaSet = this;


### PR DESCRIPTION
... the only possible value we have when creating (new) keys with the UI.

Otherwise there is no way to set the type to array of a newly created key since the default type is null and this is what the value of the key is set to.

Please do not forget to run the grunt task before committing to the repo since jsonary-core.js is also in  the repo...

Thanks
Ognian
