### PR TITLE
- static options for adaptive table: pagingRows

### DIFF
--- a/renderers/contributed/adaptive-table.js
+++ b/renderers/contributed/adaptive-table.js
@@ -7,7 +7,7 @@ Jsonary.render.register(Jsonary.plugins.Generator({
         var FancyTableRenderer = Jsonary.plugins.FancyTableRenderer;
 
         var detectedPagingLinks = !!(data.getLink('next') || data.getLink('prev'));
-        var isShort = data.readOnly() && data.length() < (Jsonary.options.adaptive_table.pagingRows ? Jsonary.options.adaptive_table.pagingRows : 15);
+        var isShort = data.readOnly() && data.length() < (Jsonary && Jsonary.options && Jsonary.options.adaptive_table && Jsonary.options.adaptive_table.pagingRows ? Jsonary.options.adaptive_table.pagingRows : 15);
 
         var renderer = new FancyTableRenderer({
             sort: {},


### PR DESCRIPTION
By setting such an option

```
Jsonary.options = {
    adaptive_table: {
        pagingRows: 30
    }
};
```

the paging can be changed...
