### PR TITLE
- do not display schema_switcher if xorSchemas.length is 0

### DIFF
--- a/jsonary/schemaset.js
+++ b/jsonary/schemaset.js
@@ -1103,7 +1103,7 @@ SchemaList.prototype = {
 			return undefined;
 		}
 		var thisSchemaSet = this;
-		var candidate = {};
+		var candidate = origValue?origValue:{};
 		var pending = 1;
 		var requiredProperties = this.requiredProperties();
 		for (var i = 0; candidate && i < requiredProperties.length; i++) {

--- a/jsonary/schemaset.js
+++ b/jsonary/schemaset.js
@@ -1103,7 +1103,7 @@ SchemaList.prototype = {
 			return undefined;
 		}
 		var thisSchemaSet = this;
-		var candidate = origValue?origValue:{};
+		var candidate = {};
 		var pending = 1;
 		var requiredProperties = this.requiredProperties();
 		for (var i = 0; candidate && i < requiredProperties.length; i++) {

--- a/renderers/plain.jsonary.js
+++ b/renderers/plain.jsonary.js
@@ -191,7 +191,7 @@
 			var orSchemas = fixedSchemas.orSchemas();
 			if (orSchemas.length == 0) {
 				xorSchemas = fixedSchemas.xorSchemas();
-				if (xorSchemas.length == 1) {
+				if (xorSchemas.length <= 1) {
 					singleOption = true;
 				}
 			}


### PR DESCRIPTION
In cases like the below one I got a schema_switcher with no entries to choose from, so I changed the comparison so that no schema_switcher is displayed in that case.
```
"importMethod": {
                    "type": "string",
                    "title": "Art des Imports",
                    "displayOrder": 3,
                    "links": [
                        {
                            "rel": "describedby",
                            "href": "/SCHEMAQUERIES/importMethod"
                        }
                    ]
                },
```